### PR TITLE
Bugfix/send request interface to guzzle instead of server request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.0.2] - 2020-10-08
+### Fixed
+ - Send `RequestInterface` instance to Guzzle instead of `ServerRequestInterface`
+
 ## [3.0.1] - 2020-10-08
 ### Fixed
  - Request object is immutable so must be assigned back when using `with` methods

--- a/src/Generator/Implementation/HttpMessage/GuzzleHttpMessage.php
+++ b/src/Generator/Implementation/HttpMessage/GuzzleHttpMessage.php
@@ -4,7 +4,7 @@ namespace DoclerLabs\ApiClientGenerator\Generator\Implementation\HttpMessage;
 
 use DoclerLabs\ApiClientGenerator\Generator\Implementation\HttpMessageImplementationInterface;
 use DoclerLabs\ApiClientGenerator\Generator\Implementation\HttpMessageImplementationStrategy;
-use GuzzleHttp\Psr7\ServerRequest;
+use GuzzleHttp\Psr7\Request;
 
 class GuzzleHttpMessage extends HttpMessageAbstract implements HttpMessageImplementationInterface
 {
@@ -23,7 +23,7 @@ class GuzzleHttpMessage extends HttpMessageAbstract implements HttpMessageImplem
     public function getInitMessageImports(): array
     {
         return [
-            ServerRequest::class,
+            Request::class,
         ];
     }
 }

--- a/src/Generator/Implementation/HttpMessage/NyholmHttpMessage.php
+++ b/src/Generator/Implementation/HttpMessage/NyholmHttpMessage.php
@@ -4,7 +4,7 @@ namespace DoclerLabs\ApiClientGenerator\Generator\Implementation\HttpMessage;
 
 use DoclerLabs\ApiClientGenerator\Generator\Implementation\HttpMessageImplementationInterface;
 use DoclerLabs\ApiClientGenerator\Generator\Implementation\HttpMessageImplementationStrategy;
-use Nyholm\Psr7\ServerRequest;
+use Nyholm\Psr7\Request;
 
 class NyholmHttpMessage extends HttpMessageAbstract implements HttpMessageImplementationInterface
 {
@@ -23,7 +23,7 @@ class NyholmHttpMessage extends HttpMessageAbstract implements HttpMessageImplem
     public function getInitMessageImports(): array
     {
         return [
-            ServerRequest::class,
+            Request::class,
         ];
     }
 }

--- a/src/Generator/RequestMapperGenerator.php
+++ b/src/Generator/RequestMapperGenerator.php
@@ -9,8 +9,9 @@ use DoclerLabs\ApiClientGenerator\Naming\CopiedNamespace;
 use DoclerLabs\ApiClientGenerator\Output\Copy\Request\RequestInterface;
 use DoclerLabs\ApiClientGenerator\Output\Copy\Serializer\BodySerializer;
 use DoclerLabs\ApiClientGenerator\Output\Php\PhpFileCollection;
+use GuzzleHttp\Cookie\CookieJar;
 use PhpParser\Node\Stmt\ClassMethod;
-use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\RequestInterface as PsrRequestInterface;
 
 class RequestMapperGenerator extends MutatorAccessorClassGeneratorAbstract
 {
@@ -30,7 +31,8 @@ class RequestMapperGenerator extends MutatorAccessorClassGeneratorAbstract
     public function generate(Specification $specification, PhpFileCollection $fileRegistry): void
     {
         $this
-            ->addImport(CopiedNamespace::getImport($this->baseNamespace, BodySerializer::class));
+            ->addImport(CopiedNamespace::getImport($this->baseNamespace, BodySerializer::class))
+            ->addImport(CookieJar::class);
 
         foreach ($this->messageImplementation->getInitMessageImports() as $import) {
             $this->addImport($import);
@@ -78,7 +80,7 @@ class RequestMapperGenerator extends MutatorAccessorClassGeneratorAbstract
     protected function generateMap(): ClassMethod
     {
         $this
-            ->addImport(ServerRequestInterface::class)
+            ->addImport(PsrRequestInterface::class, 'PsrRequestInterface')
             ->addImport(CopiedNamespace::getImport($this->baseNamespace, RequestInterface::class));
 
         $requestParam = $this->builder
@@ -90,8 +92,8 @@ class RequestMapperGenerator extends MutatorAccessorClassGeneratorAbstract
             ->generateRequestMapMethod()
             ->makePublic()
             ->addParam($requestParam)
-            ->setReturnType('ServerRequestInterface')
-            ->composeDocBlock([$requestParam], 'ServerRequestInterface')
+            ->setReturnType('PsrRequestInterface')
+            ->composeDocBlock([$requestParam], 'PsrRequestInterface')
             ->getNode();
     }
 }

--- a/src/Output/Copy/Request/Mapper/RequestMapperInterface.php
+++ b/src/Output/Copy/Request/Mapper/RequestMapperInterface.php
@@ -3,9 +3,9 @@
 namespace DoclerLabs\ApiClientGenerator\Output\Copy\Request\Mapper;
 
 use DoclerLabs\ApiClientGenerator\Output\Copy\Request\RequestInterface;
-use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\RequestInterface as PsrRequestInterface;
 
 interface RequestMapperInterface
 {
-    public function map(RequestInterface $request): ServerRequestInterface;
+    public function map(RequestInterface $request): PsrRequestInterface;
 }

--- a/test/suite/functional/Generator/RequestMapper/GuzzleRequestMapper.php
+++ b/test/suite/functional/Generator/RequestMapper/GuzzleRequestMapper.php
@@ -8,8 +8,9 @@
 
 namespace Test\Request\Mapper;
 
-use GuzzleHttp\Psr7\ServerRequest;
-use Psr\Http\Message\ServerRequestInterface;
+use GuzzleHttp\Cookie\CookieJar;
+use GuzzleHttp\Psr7\Request;
+use Psr\Http\Message\RequestInterface as PsrRequestInterface;
 use Test\Request\RequestInterface;
 use Test\Serializer\BodySerializer;
 
@@ -29,14 +30,16 @@ class GuzzleRequestMapper implements RequestMapperInterface
     /**
      * @param RequestInterface $request
      *
-     * @return ServerRequestInterface
+     * @return PsrRequestInterface
      */
-    public function map(RequestInterface $request): ServerRequestInterface
+    public function map(RequestInterface $request): PsrRequestInterface
     {
         $body        = $this->bodySerializer->serializeRequest($request);
-        $psr7Request = new ServerRequest($request->getMethod(), $request->getRoute(), $request->getHeaders(), $body, '1.1', []);
-        $psr7Request = $psr7Request->withQueryParams($request->getQueryParameters());
-        $psr7Request = $psr7Request->withCookieParams($request->getCookies());
+        $query       = \http_build_query($request->getQueryParameters(), '', '&', PHP_QUERY_RFC3986);
+        $psr7Request = new Request($request->getMethod(), $request->getRoute(), $request->getHeaders(), $body, '1.1');
+        $psr7Request = $psr7Request->withUri($psr7Request->getUri()->withQuery($query));
+        $cookieJar   = new CookieJar(true, $request->getCookies());
+        $psr7Request = $cookieJar->withCookieHeader($psr7Request);
 
         return $psr7Request;
     }


### PR DESCRIPTION
Currently, code is sending `ServerRequestInterface` instance (which extends
`RequestInterface`) to Guzzle. Nothing breaks, apparently, but Guzzle isn't
aware of extra methods from `ServerRequestInterface`, meaning whatever it's
set which is not on `RequestInterface` is completely ignored.

This PR intends to change `ServerRequest` to `Request`, and properly add
query parameters and cookies (considering `RequestInterface` lacks methods
such as `withQueryParameters` and `withCookies`).