### PR TITLE
Serialize collection items manually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.0.3] - 2020-10-15
+### Fixed
+ - Serialize items from collection manually, since `json_encode` won't call `toArray` automatically as it used to do with `jsonSerialize`
+
 ## [3.0.2] - 2020-10-08
 ### Fixed
  - Send `RequestInterface` instance to Guzzle instead of `ServerRequestInterface`

--- a/test/suite/functional/Generator/SchemaCollection/ItemCollectionPhp70.php
+++ b/test/suite/functional/Generator/SchemaCollection/ItemCollectionPhp70.php
@@ -30,7 +30,12 @@ class ItemCollection implements IteratorAggregate, SerializableInterface, Counta
      */
     public function toArray(): array
     {
-        return $this->items;
+        $return = [];
+        foreach ($this->items as $item) {
+            $return[] = $item->toArray();
+        }
+
+        return $return;
     }
 
     /**

--- a/test/suite/functional/Generator/SchemaCollection/ItemCollectionPhp72.php
+++ b/test/suite/functional/Generator/SchemaCollection/ItemCollectionPhp72.php
@@ -30,7 +30,12 @@ class ItemCollection implements IteratorAggregate, SerializableInterface, Counta
      */
     public function toArray(): array
     {
-        return $this->items;
+        $return = [];
+        foreach ($this->items as $item) {
+            $return[] = $item->toArray();
+        }
+
+        return $return;
     }
 
     /**

--- a/test/suite/functional/Generator/SchemaCollection/ItemCollectionPhp74.php
+++ b/test/suite/functional/Generator/SchemaCollection/ItemCollectionPhp74.php
@@ -29,7 +29,12 @@ class ItemCollection implements IteratorAggregate, SerializableInterface, Counta
      */
     public function toArray(): array
     {
-        return $this->items;
+        $return = [];
+        foreach ($this->items as $item) {
+            $return[] = $item->toArray();
+        }
+
+        return $return;
     }
 
     /**


### PR DESCRIPTION
Before, when serialization was done via `JsonSerializable`,
`json_encode` would call `jsonSerialize` automatically for us when
serializing a collection. Now with `toArray`, we need to do it manually.