### PR TITLE
Fix `Content-Type` header handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.0.3] - 2020-10-15
+### Fixed
+- Fix `Content-type` header handling.
+
 ## [3.0.2] - 2020-10-08
 ### Fixed
  - Send `RequestInterface` instance to Guzzle instead of `ServerRequestInterface`

--- a/README.md
+++ b/README.md
@@ -38,3 +38,10 @@ The following environment variables are available:
 | `CLIENT_PHP_VERSION` | no | 7.0 | 7.0 |
 | `COMPOSER_JSON_TEMPLATE_DIR` | no | {path-to-repository}/template/composer.json.twig | /path/composer.json.twig |
 | `README_MD_TEMPLATE_DIR` | no | {path-to-repository}/template/README.md.twig | /path/README.md.twig |
+
+
+## Running tests
+
+```bash
+docker run  -w /app -v $(pwd):/app  php:7.4-cli-alpine php /app/vendor/bin/phpunit -c /app/phpunit.xml.dist --colors=always
+```

--- a/src/Output/Copy/Response/ResponseHandler.php
+++ b/src/Output/Copy/Response/ResponseHandler.php
@@ -10,6 +10,7 @@ class ResponseHandler
 {
     /** @var BodySerializer */
     private $bodySerializer;
+
     /** @var ResponseExceptionFactory */
     private $responseExceptionFactory;
 

--- a/src/Output/Copy/Serializer/BodySerializer.php
+++ b/src/Output/Copy/Serializer/BodySerializer.php
@@ -14,7 +14,7 @@ use Throwable;
 class BodySerializer
 {
     /** @var ContentTypeSerializerInterface[] */
-    private array $contentTypeSerializers = [];
+    private $contentTypeSerializers = [];
 
     public function add(string $contentType, ContentTypeSerializerInterface $contentTypeSerializer): self
     {

--- a/src/Output/Copy/Serializer/BodySerializer.php
+++ b/src/Output/Copy/Serializer/BodySerializer.php
@@ -14,7 +14,7 @@ use Throwable;
 class BodySerializer
 {
     /** @var ContentTypeSerializerInterface[] */
-    private $contentTypeSerializers = [];
+    private array $contentTypeSerializers = [];
 
     public function add(string $contentType, ContentTypeSerializerInterface $contentTypeSerializer): self
     {
@@ -59,12 +59,14 @@ class BodySerializer
 
     private function getContentTypeSerializer(string $contentType): ContentTypeSerializerInterface
     {
+        $contentType = strtolower(trim(explode(';', $contentType)[0]));
+
         if (!isset($this->contentTypeSerializers[$contentType])) {
             throw new InvalidArgumentException(
-                \sprintf(
+                sprintf(
                     'Serializer for `%s` is not found. Supported: %s',
                     $contentType,
-                    Json::encode(\array_keys($this->contentTypeSerializers))
+                    Json::encode(array_keys($this->contentTypeSerializers))
                 )
             );
         }

--- a/test/suite/functional/Output/Copy/Serializer/BodySerializerTest.php
+++ b/test/suite/functional/Output/Copy/Serializer/BodySerializerTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoclerLabs\ApiClientGenerator\Test\Functional\Output\Copy\Serializer;
+
+use DoclerLabs\ApiClientException\UnexpectedResponseException;
+use DoclerLabs\ApiClientGenerator\Output\Copy\Serializer\BodySerializer;
+use DoclerLabs\ApiClientGenerator\Output\Copy\Serializer\ContentType\FormUrlencodedContentTypeSerializer;
+use DoclerLabs\ApiClientGenerator\Output\Copy\Serializer\ContentType\Json\Json;
+use DoclerLabs\ApiClientGenerator\Output\Copy\Serializer\ContentType\JsonContentTypeSerializer;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Stream;
+use PHPUnit\Framework\TestCase;
+
+class BodySerializerTest extends TestCase
+{
+    private BodySerializer $sut;
+
+    public function setUp(): void
+    {
+        $this->sut = new BodySerializer();
+        $this->sut
+            ->add('application/json', new JsonContentTypeSerializer())
+            ->add('application/x-www-form-urlencoded', new FormUrlencodedContentTypeSerializer());
+    }
+
+    public function testUnserializeJsonResponseForEmptyBody(): void
+    {
+        $response = $this->getResponse('application/json', '');
+
+        self::assertEquals([], $this->sut->unserializeResponse($response));
+    }
+
+    public function testExceptionIsThrownForUnsupportedContentType(): void
+    {
+        $this->expectException(UnexpectedResponseException::class);
+        $response = $this->getResponse('video/h264', 'body content');
+
+        $this->sut->unserializeResponse($response);
+    }
+
+    public function testUnserializeFormUrlencodedResponse(): void
+    {
+        $response = $this->getResponse('application/x-www-form-urlencoded', 'key=value');
+
+        self::assertEquals(['key' => 'value'], $this->sut->unserializeResponse($response));
+    }
+
+    /**
+     * @dataProvider applicationJsonContentTypeStringsProvider
+     */
+    public function testUnserializeJsonResponse(string $contentType): void
+    {
+        $body        = ['key' => 'value'];
+        $encodedBody = Json::encode($body);
+
+        $response = $this->getResponse($contentType, $encodedBody);
+
+        self::assertEquals($body, $this->sut->unserializeResponse($response));
+    }
+
+    public function applicationJsonContentTypeStringsProvider(): array
+    {
+        return [
+            'default'            => [
+                'application/json',
+            ],
+            'with extra symbols' => [
+                'application/json; ',
+            ],
+            'upper case'         => [
+                'applicaTion/JSON',
+            ],
+            'with charset'       => [
+                'application/json; charset=ISO-8859-4',
+            ],
+        ];
+    }
+
+    private function getResponse(string $contentType, string $body): Response
+    {
+        /** @var Response $response */
+        $response = (new Response())->withHeader('Content-type', $contentType);
+
+        if ($body) {
+            $resource     = fopen('php://memory', 'wb+');
+            $guzzleStream = new Stream($resource);
+            $guzzleStream->write($body);
+            $response = $response->withBody($guzzleStream);
+        }
+
+        return $response;
+    }
+}

--- a/test/suite/functional/Output/Copy/Serializer/BodySerializerTest.php
+++ b/test/suite/functional/Output/Copy/Serializer/BodySerializerTest.php
@@ -17,7 +17,7 @@ class BodySerializerTest extends TestCase
 {
     private BodySerializer $sut;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->sut = new BodySerializer();
         $this->sut


### PR DESCRIPTION
Content-Type header can have various forms, according to [RFC 7231](https://tools.ietf.org/html/rfc7231#section-3.1.1.5).
This PR fixes the behaviour of generated client in case when `Content-Type` contains charset, or any other utility symbols.

Coverage increased by 1.0% 
<img width="555" alt="image" src="https://user-images.githubusercontent.com/919655/96227530-8839d500-0f94-11eb-9a42-24c6f9277300.png">
