### PR TITLE
fix: api generator doesn't support mixed type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [5.3.0] - 2021-04-13
 ### Added
  - Support for `mixed` parameter type
+ - Support for anyOf `mixed` parameter type
 
 ### Fixed
  - `mixed` arrays rendered incorrectly
+ - Wrong typehint in case of nullable arrays
 
 ## [5.2.0] - 2021-04-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-## [5.2.1] - 2021-04-12
-### Fixed
+## [5.3.0] - 2021-04-13
+### Added
  - Support for `mixed` parameter type
+
+### Fixed
+ - `mixed` arrays rendered incorrectly
 
 ## [5.2.0] - 2021-04-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [5.2.1] - 2021-04-12
+### Fixed
+ - Support for `mixed` parameter type
+
 ## [5.2.0] - 2021-04-06
 ### Added
  - Support for `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `minItems`, `maxItems`, `pattern`, `maxLength`, `minLength` validations

--- a/example/gen/src/Schema/TagCollection.php
+++ b/example/gen/src/Schema/TagCollection.php
@@ -18,7 +18,7 @@ class TagCollection implements IteratorAggregate, SerializableInterface, Countab
     private array $items;
 
     /**
-     * @param Tag|null[] $items
+     * @param Tag[] $items
      */
     public function __construct(Tag ...$items)
     {

--- a/src/Ast/Builder/CodeBuilder.php
+++ b/src/Ast/Builder/CodeBuilder.php
@@ -140,7 +140,7 @@ class CodeBuilder extends BuilderFactory
             ->property($name)
             ->makePrivate();
 
-        if ($this->phpVersion->isPropertyTypeHintSupported()) {
+        if (!empty($type) && $this->phpVersion->isPropertyTypeHintSupported()) {
             if ($nullable) {
                 $property->setDefault(null);
                 $type = '?' . $type;

--- a/src/Ast/Builder/MethodBuilder.php
+++ b/src/Ast/Builder/MethodBuilder.php
@@ -12,6 +12,8 @@ use PhpParser\Node\NullableType;
 
 class MethodBuilder extends Method
 {
+    public const RETURN_TYPE_VOID = 'void';
+
     private PhpVersion $phpVersion;
 
     public function __construct(string $name, PhpVersion $phpVersion)
@@ -59,13 +61,13 @@ class MethodBuilder extends Method
      */
     public function setReturnType($type, $isNullable = false): self
     {
-        if ($type === 'mixed') {
+        if (empty($type)) {
             return $this;
         }
 
-        if ($type === null) {
+        if ($type === self::RETURN_TYPE_VOID) {
             if ($this->phpVersion->isVoidReturnTypeSupported()) {
-                return parent::setReturnType('void');
+                return parent::setReturnType($type);
             }
 
             return $this;

--- a/src/Ast/Builder/ParameterBuilder.php
+++ b/src/Ast/Builder/ParameterBuilder.php
@@ -20,7 +20,7 @@ class ParameterBuilder extends Param
 
     public function setType($type, bool $isNullable = false): self
     {
-        if ($type === 'mixed') {
+        if (empty($type)) {
             return $this;
         }
 

--- a/src/Ast/Builder/ParameterBuilder.php
+++ b/src/Ast/Builder/ParameterBuilder.php
@@ -20,6 +20,10 @@ class ParameterBuilder extends Param
 
     public function setType($type, bool $isNullable = false): self
     {
+        if ($type === 'mixed') {
+            return $this;
+        }
+
         if ($isNullable) {
             if ($this->phpVersion->isNullableTypeHintSupported() && is_string($type)) {
                 return parent::setType(sprintf('?%s', $type));

--- a/src/Entity/Field.php
+++ b/src/Entity/Field.php
@@ -185,6 +185,10 @@ class Field
             return $this->getPhpClassName();
         }
 
+        if ($this->type->isMixed()) {
+            return self::TYPE_MIXED;
+        }
+
         return $this->type->toPhpType();
     }
 

--- a/src/Entity/Field.php
+++ b/src/Entity/Field.php
@@ -208,11 +208,7 @@ class Field
 
         if ($this->isArray() && !$this->isArrayOfObjects()) {
             $arraySuffix = '[]';
-            $arrayItem = $this->getArrayItem();
-
-            $typeHint = $arrayItem->getType()->isMixed()
-                ? self::TYPE_MIXED
-                : $arrayItem->getPhpTypeHint();
+            $typeHint = $this->getArrayItem()->getPhpDocType();
         }
 
         return sprintf('%s%s%s', $typeHint, $arraySuffix, $nullableSuffix);

--- a/src/Entity/Field.php
+++ b/src/Entity/Field.php
@@ -185,10 +185,6 @@ class Field
             return $this->getPhpClassName();
         }
 
-        if ($this->type->isMixed()) {
-            return self::TYPE_MIXED;
-        }
-
         return $this->type->toPhpType();
     }
 

--- a/src/Entity/Field.php
+++ b/src/Entity/Field.php
@@ -208,7 +208,11 @@ class Field
 
         if ($this->isArray() && !$this->isArrayOfObjects()) {
             $arraySuffix = '[]';
-            $typeHint    = $this->getArrayItem()->getPhpTypeHint();
+            $arrayItem = $this->getArrayItem();
+
+            $typeHint = $arrayItem->getType()->isMixed()
+                ? self::TYPE_MIXED
+                : $arrayItem->getPhpTypeHint();
         }
 
         return sprintf('%s%s%s', $typeHint, $arraySuffix, $nullableSuffix);

--- a/src/Generator/ClientGenerator.php
+++ b/src/Generator/ClientGenerator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DoclerLabs\ApiClientGenerator\Generator;
 
+use DoclerLabs\ApiClientGenerator\Ast\Builder\MethodBuilder;
 use DoclerLabs\ApiClientGenerator\Entity\Operation;
 use DoclerLabs\ApiClientGenerator\Input\Specification;
 use DoclerLabs\ApiClientGenerator\Naming\ClientNaming;
@@ -107,7 +108,7 @@ class ClientGenerator extends GeneratorAbstract
                 ->makePublic()
                 ->addParam($methodParam)
                 ->addStmt($handleResponseStmt)
-                ->setReturnType(null)
+                ->setReturnType(MethodBuilder::RETURN_TYPE_VOID)
                 ->composeDocBlock([$methodParam])
                 ->getNode();
         }

--- a/src/Generator/ServiceProviderGenerator.php
+++ b/src/Generator/ServiceProviderGenerator.php
@@ -4,6 +4,7 @@ namespace DoclerLabs\ApiClientGenerator\Generator;
 
 use DoclerLabs\ApiClientException\Factory\ResponseExceptionFactory;
 use DoclerLabs\ApiClientGenerator\Ast\Builder\CodeBuilder;
+use DoclerLabs\ApiClientGenerator\Ast\Builder\MethodBuilder;
 use DoclerLabs\ApiClientGenerator\Entity\Field;
 use DoclerLabs\ApiClientGenerator\Entity\Operation;
 use DoclerLabs\ApiClientGenerator\Generator\Implementation\ContainerImplementationStrategy;
@@ -167,7 +168,7 @@ class ServiceProviderGenerator extends GeneratorAbstract
             ->addParam($param)
             ->addStmts($statements)
             ->composeDocBlock([$param], '', [])
-            ->setReturnType(null)
+            ->setReturnType(MethodBuilder::RETURN_TYPE_VOID)
             ->getNode();
     }
 

--- a/src/Input/Factory/FieldFactory.php
+++ b/src/Input/Factory/FieldFactory.php
@@ -80,7 +80,7 @@ class FieldFactory
                     $operationName,
                     lcfirst($itemReferenceName),
                     $sibling,
-                    $required,
+                    true,
                     $itemReferenceName
                 );
             } elseif (FieldType::isSpecificationTypeObject($type)) {

--- a/test/suite/functional/Generator/Schema/ItemPhp70.php
+++ b/test/suite/functional/Generator/Schema/ItemPhp70.php
@@ -56,6 +56,10 @@ class Item implements SerializableInterface, JsonSerializable
     /** @var ItemMandatoryObject */
     private $mandatoryObject;
 
+    private $mandatoryMixed;
+
+    private $mandatoryAnyOf;
+
     /** @var ItemNullableObject|null */
     private $nullableObject;
 
@@ -114,7 +118,7 @@ class Item implements SerializableInterface, JsonSerializable
      *
      * @throws RequestValidationException
      */
-    public function __construct(int $mandatoryInteger, string $mandatoryString, string $mandatoryEnum, DateTimeInterface $mandatoryDate, $mandatoryNullableDate, float $mandatoryFloat, bool $mandatoryBoolean, array $mandatoryArray, array $mandatoryArrayWithMinItems, ItemMandatoryObject $mandatoryObject)
+    public function __construct(int $mandatoryInteger, string $mandatoryString, string $mandatoryEnum, DateTimeInterface $mandatoryDate, $mandatoryNullableDate, float $mandatoryFloat, bool $mandatoryBoolean, array $mandatoryArray, array $mandatoryArrayWithMinItems, ItemMandatoryObject $mandatoryObject, $mandatoryMixed, $mandatoryAnyOf)
     {
         $this->mandatoryInteger = $mandatoryInteger;
         $this->mandatoryString  = $mandatoryString;
@@ -132,6 +136,8 @@ class Item implements SerializableInterface, JsonSerializable
         }
         $this->mandatoryArrayWithMinItems = $mandatoryArrayWithMinItems;
         $this->mandatoryObject            = $mandatoryObject;
+        $this->mandatoryMixed             = $mandatoryMixed;
+        $this->mandatoryAnyOf             = $mandatoryAnyOf;
     }
 
     /**
@@ -389,6 +395,16 @@ class Item implements SerializableInterface, JsonSerializable
         return $this->mandatoryObject;
     }
 
+    public function getMandatoryMixed()
+    {
+        return $this->mandatoryMixed;
+    }
+
+    public function getMandatoryAnyOf()
+    {
+        return $this->mandatoryAnyOf;
+    }
+
     /**
      * @return ItemNullableObject|null
      */
@@ -538,6 +554,8 @@ class Item implements SerializableInterface, JsonSerializable
         $fields['mandatoryArray']             = $this->mandatoryArray;
         $fields['mandatoryArrayWithMinItems'] = $this->mandatoryArrayWithMinItems;
         $fields['mandatoryObject']            = $this->mandatoryObject->toArray();
+        $fields['mandatoryMixed']             = $this->mandatoryMixed;
+        $fields['mandatoryAnyOf']             = $this->mandatoryAnyOf;
         $fields['nullableObject']             = $this->nullableObject !== null ? $this->nullableObject->toArray() : null;
         $fields['nullableDate']               = $this->nullableDate   !== null ? $this->nullableDate->format(DATE_RFC3339) : null;
         if ($this->optionalInteger !== null) {

--- a/test/suite/functional/Generator/Schema/ItemPhp70.php
+++ b/test/suite/functional/Generator/Schema/ItemPhp70.php
@@ -87,6 +87,9 @@ class Item implements SerializableInterface, JsonSerializable
     /** @var string[]|null */
     private $optionalArray;
 
+    /** @var mixed[]|null */
+    private $optionalMixedArray;
+
     /** @var string[]|null */
     private $optionalArrayWithMinMaxItems;
 
@@ -214,6 +217,16 @@ class Item implements SerializableInterface, JsonSerializable
     public function setOptionalArray(array $optionalArray): self
     {
         $this->optionalArray = $optionalArray;
+
+        return $this;
+    }
+
+    /**
+     * @param mixed[] $optionalMixedArray
+     */
+    public function setOptionalMixedArray(array $optionalMixedArray): self
+    {
+        $this->optionalMixedArray = $optionalMixedArray;
 
         return $this;
     }
@@ -478,6 +491,14 @@ class Item implements SerializableInterface, JsonSerializable
     }
 
     /**
+     * @return mixed[]|null
+     */
+    public function getOptionalMixedArray()
+    {
+        return $this->optionalMixedArray;
+    }
+
+    /**
      * @return string[]|null
      */
     public function getOptionalArrayWithMinMaxItems()
@@ -578,6 +599,9 @@ class Item implements SerializableInterface, JsonSerializable
         }
         if ($this->optionalArray !== null) {
             $fields['optionalArray'] = $this->optionalArray;
+        }
+        if ($this->optionalMixedArray !== null) {
+            $fields['optionalMixedArray'] = $this->optionalMixedArray;
         }
         if ($this->optionalArrayWithMinMaxItems !== null) {
             $fields['optionalArrayWithMinMaxItems'] = $this->optionalArrayWithMinMaxItems;

--- a/test/suite/functional/Generator/Schema/ItemPhp72.php
+++ b/test/suite/functional/Generator/Schema/ItemPhp72.php
@@ -56,6 +56,10 @@ class Item implements SerializableInterface, JsonSerializable
     /** @var ItemMandatoryObject */
     private $mandatoryObject;
 
+    private $mandatoryMixed;
+
+    private $mandatoryAnyOf;
+
     /** @var ItemNullableObject|null */
     private $nullableObject;
 
@@ -113,7 +117,7 @@ class Item implements SerializableInterface, JsonSerializable
      *
      * @throws RequestValidationException
      */
-    public function __construct(int $mandatoryInteger, string $mandatoryString, string $mandatoryEnum, DateTimeInterface $mandatoryDate, ?DateTimeInterface $mandatoryNullableDate, float $mandatoryFloat, bool $mandatoryBoolean, array $mandatoryArray, array $mandatoryArrayWithMinItems, ItemMandatoryObject $mandatoryObject)
+    public function __construct(int $mandatoryInteger, string $mandatoryString, string $mandatoryEnum, DateTimeInterface $mandatoryDate, ?DateTimeInterface $mandatoryNullableDate, float $mandatoryFloat, bool $mandatoryBoolean, array $mandatoryArray, array $mandatoryArrayWithMinItems, ItemMandatoryObject $mandatoryObject, $mandatoryMixed, $mandatoryAnyOf)
     {
         $this->mandatoryInteger = $mandatoryInteger;
         $this->mandatoryString  = $mandatoryString;
@@ -131,6 +135,8 @@ class Item implements SerializableInterface, JsonSerializable
         }
         $this->mandatoryArrayWithMinItems = $mandatoryArrayWithMinItems;
         $this->mandatoryObject            = $mandatoryObject;
+        $this->mandatoryMixed             = $mandatoryMixed;
+        $this->mandatoryAnyOf             = $mandatoryAnyOf;
     }
 
     public function setNullableObject(?ItemNullableObject $nullableObject): self
@@ -379,6 +385,16 @@ class Item implements SerializableInterface, JsonSerializable
         return $this->mandatoryObject;
     }
 
+    public function getMandatoryMixed()
+    {
+        return $this->mandatoryMixed;
+    }
+
+    public function getMandatoryAnyOf()
+    {
+        return $this->mandatoryAnyOf;
+    }
+
     public function getNullableObject(): ?ItemNullableObject
     {
         return $this->nullableObject;
@@ -483,6 +499,8 @@ class Item implements SerializableInterface, JsonSerializable
         $fields['mandatoryArray']             = $this->mandatoryArray;
         $fields['mandatoryArrayWithMinItems'] = $this->mandatoryArrayWithMinItems;
         $fields['mandatoryObject']            = $this->mandatoryObject->toArray();
+        $fields['mandatoryMixed']             = $this->mandatoryMixed;
+        $fields['mandatoryAnyOf']             = $this->mandatoryAnyOf;
         $fields['nullableObject']             = $this->nullableObject !== null ? $this->nullableObject->toArray() : null;
         $fields['nullableDate']               = $this->nullableDate   !== null ? $this->nullableDate->format(DATE_RFC3339) : null;
         if ($this->optionalInteger !== null) {

--- a/test/suite/functional/Generator/Schema/ItemPhp72.php
+++ b/test/suite/functional/Generator/Schema/ItemPhp72.php
@@ -87,6 +87,9 @@ class Item implements SerializableInterface, JsonSerializable
     /** @var string[]|null */
     private $optionalArray;
 
+    /** @var mixed[]|null */
+    private $optionalMixedArray;
+
     /** @var string[]|null */
     private $optionalArrayWithMinMaxItems;
 
@@ -207,6 +210,16 @@ class Item implements SerializableInterface, JsonSerializable
     public function setOptionalArray(array $optionalArray): self
     {
         $this->optionalArray = $optionalArray;
+
+        return $this;
+    }
+
+    /**
+     * @param mixed[] $optionalMixedArray
+     */
+    public function setOptionalMixedArray(array $optionalMixedArray): self
+    {
+        $this->optionalMixedArray = $optionalMixedArray;
 
         return $this;
     }
@@ -444,6 +457,14 @@ class Item implements SerializableInterface, JsonSerializable
     }
 
     /**
+     * @return mixed[]|null
+     */
+    public function getOptionalMixedArray(): ?array
+    {
+        return $this->optionalMixedArray;
+    }
+
+    /**
      * @return string[]|null
      */
     public function getOptionalArrayWithMinMaxItems(): ?array
@@ -523,6 +544,9 @@ class Item implements SerializableInterface, JsonSerializable
         }
         if ($this->optionalArray !== null) {
             $fields['optionalArray'] = $this->optionalArray;
+        }
+        if ($this->optionalMixedArray !== null) {
+            $fields['optionalMixedArray'] = $this->optionalMixedArray;
         }
         if ($this->optionalArrayWithMinMaxItems !== null) {
             $fields['optionalArrayWithMinMaxItems'] = $this->optionalArrayWithMinMaxItems;

--- a/test/suite/functional/Generator/Schema/ItemPhp74.php
+++ b/test/suite/functional/Generator/Schema/ItemPhp74.php
@@ -68,6 +68,8 @@ class Item implements SerializableInterface, JsonSerializable
 
     private ?array $optionalArray = null;
 
+    private ?array $optionalMixedArray = null;
+
     private ?array $optionalArrayWithMinMaxItems = null;
 
     private ?string $optionalStringWithMinMaxLength = null;
@@ -180,6 +182,16 @@ class Item implements SerializableInterface, JsonSerializable
     public function setOptionalArray(array $optionalArray): self
     {
         $this->optionalArray = $optionalArray;
+
+        return $this;
+    }
+
+    /**
+     * @param mixed[] $optionalMixedArray
+     */
+    public function setOptionalMixedArray(array $optionalMixedArray): self
+    {
+        $this->optionalMixedArray = $optionalMixedArray;
 
         return $this;
     }
@@ -417,6 +429,14 @@ class Item implements SerializableInterface, JsonSerializable
     }
 
     /**
+     * @return mixed[]|null
+     */
+    public function getOptionalMixedArray(): ?array
+    {
+        return $this->optionalMixedArray;
+    }
+
+    /**
      * @return string[]|null
      */
     public function getOptionalArrayWithMinMaxItems(): ?array
@@ -496,6 +516,9 @@ class Item implements SerializableInterface, JsonSerializable
         }
         if ($this->optionalArray !== null) {
             $fields['optionalArray'] = $this->optionalArray;
+        }
+        if ($this->optionalMixedArray !== null) {
+            $fields['optionalMixedArray'] = $this->optionalMixedArray;
         }
         if ($this->optionalArrayWithMinMaxItems !== null) {
             $fields['optionalArrayWithMinMaxItems'] = $this->optionalArrayWithMinMaxItems;

--- a/test/suite/functional/Generator/Schema/ItemPhp74.php
+++ b/test/suite/functional/Generator/Schema/ItemPhp74.php
@@ -46,6 +46,10 @@ class Item implements SerializableInterface, JsonSerializable
 
     private ItemMandatoryObject $mandatoryObject;
 
+    private $mandatoryMixed;
+
+    private $mandatoryAnyOf;
+
     private ?ItemNullableObject $nullableObject = null;
 
     private ?DateTimeInterface $nullableDate = null;
@@ -86,7 +90,7 @@ class Item implements SerializableInterface, JsonSerializable
      *
      * @throws RequestValidationException
      */
-    public function __construct(int $mandatoryInteger, string $mandatoryString, string $mandatoryEnum, DateTimeInterface $mandatoryDate, ?DateTimeInterface $mandatoryNullableDate, float $mandatoryFloat, bool $mandatoryBoolean, array $mandatoryArray, array $mandatoryArrayWithMinItems, ItemMandatoryObject $mandatoryObject)
+    public function __construct(int $mandatoryInteger, string $mandatoryString, string $mandatoryEnum, DateTimeInterface $mandatoryDate, ?DateTimeInterface $mandatoryNullableDate, float $mandatoryFloat, bool $mandatoryBoolean, array $mandatoryArray, array $mandatoryArrayWithMinItems, ItemMandatoryObject $mandatoryObject, $mandatoryMixed, $mandatoryAnyOf)
     {
         $this->mandatoryInteger = $mandatoryInteger;
         $this->mandatoryString  = $mandatoryString;
@@ -104,6 +108,8 @@ class Item implements SerializableInterface, JsonSerializable
         }
         $this->mandatoryArrayWithMinItems = $mandatoryArrayWithMinItems;
         $this->mandatoryObject            = $mandatoryObject;
+        $this->mandatoryMixed             = $mandatoryMixed;
+        $this->mandatoryAnyOf             = $mandatoryAnyOf;
     }
 
     public function setNullableObject(?ItemNullableObject $nullableObject): self
@@ -352,6 +358,16 @@ class Item implements SerializableInterface, JsonSerializable
         return $this->mandatoryObject;
     }
 
+    public function getMandatoryMixed()
+    {
+        return $this->mandatoryMixed;
+    }
+
+    public function getMandatoryAnyOf()
+    {
+        return $this->mandatoryAnyOf;
+    }
+
     public function getNullableObject(): ?ItemNullableObject
     {
         return $this->nullableObject;
@@ -456,6 +472,8 @@ class Item implements SerializableInterface, JsonSerializable
         $fields['mandatoryArray']             = $this->mandatoryArray;
         $fields['mandatoryArrayWithMinItems'] = $this->mandatoryArrayWithMinItems;
         $fields['mandatoryObject']            = $this->mandatoryObject->toArray();
+        $fields['mandatoryMixed']             = $this->mandatoryMixed;
+        $fields['mandatoryAnyOf']             = $this->mandatoryAnyOf;
         $fields['nullableObject']             = $this->nullableObject !== null ? $this->nullableObject->toArray() : null;
         $fields['nullableDate']               = $this->nullableDate   !== null ? $this->nullableDate->format(DATE_RFC3339) : null;
         if ($this->optionalInteger !== null) {

--- a/test/suite/functional/Generator/Schema/item.yaml
+++ b/test/suite/functional/Generator/Schema/item.yaml
@@ -58,6 +58,11 @@ components:
               properties:
                 string:
                   type: string
+        mandatoryMixed: {}
+        mandatoryAnyOf:
+          anyOf:
+            - type: number
+            - type: string
         nullableObject:
           type: object
           properties:
@@ -136,6 +141,8 @@ components:
         - mandatoryArray
         - mandatoryArrayWithMinItems
         - mandatoryObject
+        - mandatoryMixed
+        - mandatoryAnyOf
     EmbeddedObject:
       type: object
       properties:

--- a/test/suite/functional/Generator/Schema/item.yaml
+++ b/test/suite/functional/Generator/Schema/item.yaml
@@ -94,6 +94,9 @@ components:
           type: array
           items:
             type: string
+        optionalMixedArray:
+          type: array
+          items: {}
         optionalArrayWithMinMaxItems:
           type: array
           minItems: 1


### PR DESCRIPTION
The api client generator currently not supporting mixed types. 
https://swagger.io/docs/specification/data-models/data-types/#any

It throws an exception when I try to use it:
```
In BuilderHelpers.php line 132:
                        
  Name cannot be empty  
```
                        
