### PR TITLE
feat: use openapi license name in generated composer.json file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [5.4.0] - 2021-04-22
+### Added
+ - Support for `license` info. Use it in the default composer.json tpl.
+
 ## [5.3.0] - 2021-04-13
 ### Added
  - Support for `mixed` parameter type

--- a/example/gen/composer.json
+++ b/example/gen/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "openapi/pet-store-client",
     "description": "Client library for Swagger Petstore - OpenAPI 3.0",
+    "license": "Apache 2.0",
     "keywords": [
         "api-client"
     ],

--- a/src/Input/Specification.php
+++ b/src/Input/Specification.php
@@ -34,6 +34,18 @@ class Specification
         return $this->openApi->info->title;
     }
 
+    public function hasLicense(): bool
+    {
+        $license = $this->openApi->info->license;
+
+        return $license && $license->name;
+    }
+
+    public function getLicenseName(): string
+    {
+        return $this->openApi->info->license->name;
+    }
+
     public function getServerUrls(): array
     {
         $serverUrls = [];

--- a/template/composer.json.twig
+++ b/template/composer.json.twig
@@ -1,7 +1,10 @@
 {
     "name": "{{ packageName }}",
     "description": "Client library for {{ specification.getTitle() }}",
-    "keywords": [
+    {% if specification.hasLicense %}
+"license": "{{ specification.getLicenseName }}",
+    {% endif %}
+"keywords": [
         "api-client"
     ],
     "config": {


### PR DESCRIPTION
The spec: https://swagger.io/specification/#license-object