### PR TITLE
Added ext-intl to the generated composer.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [7.0.1] - 2021-08-29
+### Fixed
+- Added `ext-intl` to composer.json. It was missing since 7.0.0.
+
 ## [7.0.0] - 2021-08-27
 ### Fixed
 - Using `grapheme_strlen` to properly count string lengths.

--- a/example/gen/composer.json
+++ b/example/gen/composer.json
@@ -11,6 +11,7 @@
     "require": {
         "php": ">=7.4",
         "docler-labs/api-client-exception": "^1.0",
+        "ext-intl": "*",
         "guzzlehttp/psr7": "^1.6",
         "pimple/pimple": "^3.3",
         "psr/container": "^1.0",

--- a/src/Meta/ComposerJsonTemplate.php
+++ b/src/Meta/ComposerJsonTemplate.php
@@ -61,6 +61,7 @@ class ComposerJsonTemplate implements TemplateInterface
     {
         return [
             'docler-labs/api-client-exception' => '^1.0',
+            'ext-intl'                         => '*',
             'psr/container'                    => '^1.0',
             'psr/http-client'                  => '^1.0',
             'psr/http-client-implementation'   => '^1.0',

--- a/test/suite/functional/Meta/ComposerJson/composer_default.json
+++ b/test/suite/functional/Meta/ComposerJson/composer_default.json
@@ -10,6 +10,7 @@
     "require": {
         "php": ">=7.4",
         "docler-labs/api-client-exception": "^1.0",
+        "ext-intl": "*",
         "guzzlehttp/psr7": "^1.6",
         "pimple/pimple": "^3.3",
         "psr/container": "^1.0",

--- a/test/suite/functional/Meta/ComposerJson/composer_guzzle_message.json
+++ b/test/suite/functional/Meta/ComposerJson/composer_guzzle_message.json
@@ -10,6 +10,7 @@
     "require": {
         "php": ">=7.4",
         "docler-labs/api-client-exception": "^1.0",
+        "ext-intl": "*",
         "guzzlehttp/psr7": "^1.6",
         "pimple/pimple": "^3.3",
         "psr/container": "^1.0",

--- a/test/suite/functional/Meta/ComposerJson/composer_nyholm_message.json
+++ b/test/suite/functional/Meta/ComposerJson/composer_nyholm_message.json
@@ -10,6 +10,7 @@
     "require": {
         "php": ">=7.4",
         "docler-labs/api-client-exception": "^1.0",
+        "ext-intl": "*",
         "nyholm/psr7": "^1.3",
         "pimple/pimple": "^3.3",
         "psr/container": "^1.0",


### PR DESCRIPTION
I forgot to include `ext-intl` to the generated `composer.json` as noted by @vsouz4 in https://github.com/DoclerLabs/api-client-generator/issues/49#issuecomment-907335081. This PR fixes that.