### PR TITLE
Added `Specification::getVersion()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [10.10.0] - 2025.02.12
+### Added
+- `Specification::getVersion()` method, which optionally might be used in a composer.json.twig `"version": "{{ specification.getVersion() }}"`
+
 ## [10.9.1] - 2024.12.29
 ### Fixed
 - Array to string conversion in maxItems in minItems constraints

--- a/src/Input/Specification.php
+++ b/src/Input/Specification.php
@@ -34,6 +34,11 @@ class Specification
         return $this->openApi->info->title;
     }
 
+    public function getVersion(): string
+    {
+        return $this->openApi->info->version;
+    }
+
     public function hasLicense(): bool
     {
         $license = $this->openApi->info->license;

--- a/test/suite/functional/Input/SpecificationTest.php
+++ b/test/suite/functional/Input/SpecificationTest.php
@@ -236,6 +236,39 @@ class SpecificationTest extends TestCase
         ];
     }
 
+    public function testGetFromInfo(): void
+    {
+        $data = [
+            'openapi' => '3.0.0',
+            'info'    => [
+                'title'   => 'Sample API',
+                'version' => '1.2.3',
+            ],
+            'paths' => [
+                '/foo/bar' => [
+                    'get' => [
+                        'operationId' => 'getFooBar',
+                        'responses'   => [
+                            '200' => [
+                                'description' => 'Ge',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $specification = $this->sut->parse($data, '/openapi.yaml');
+        static::assertSame('1.2.3', $specification->getVersion());
+        static::assertSame('Sample API', $specification->getTitle());
+        static::assertSame(false, $specification->hasLicense());
+
+        $data['info']['license']['name'] = 'License name';
+
+        $specificationWithLicense = $this->sut->parse($data, '/openapi.yaml');
+        static::assertSame(true, $specificationWithLicense->hasLicense());
+        static::assertSame('License name', $specificationWithLicense->getLicenseName());
+    }
+
     protected function setUp(): void
     {
         $container = $this->getContainerWith(ConfigurationBuilder::fake()->build());


### PR DESCRIPTION
Added `Specification::getVersion()` method which optionally might be used in a composer.json.twig `"version": "{{ specification.getVersion() }}"`